### PR TITLE
Prevent garbage collection of delegates, support GetOrder

### DIFF
--- a/OpenLimits/LimitOrderRequest.cs
+++ b/OpenLimits/LimitOrderRequest.cs
@@ -9,7 +9,7 @@ namespace OpenLimits
         public readonly ulong timeInForceDurationMs;
         public readonly bool postOnly;
 
-        private LimitOrderRequest(string price, string size, string market, TimeInForce timeInForce, ulong timeInForceDurationMs, bool postOnly)
+        public LimitOrderRequest(string price, string size, string market, TimeInForce timeInForce, ulong timeInForceDurationMs, bool postOnly)
         {
             this.price = price;
             this.size = size;

--- a/OpenLimits/Order.cs
+++ b/OpenLimits/Order.cs
@@ -12,6 +12,7 @@ namespace OpenLimits
         public readonly OrderStatus status;
         public readonly double size;
         public readonly double price;
+        public readonly double remaining;
 
         public void Dispose() {
             ExchangeClient.FreeString(id);
@@ -29,7 +30,8 @@ namespace OpenLimits
                 this.side,
                 this.status,
                 this.size,
-                this.price
+                this.price,
+                this.remaining
             );
         }
     }
@@ -45,8 +47,9 @@ namespace OpenLimits
         public readonly OrderStatus status;
         public readonly double size;
         public readonly double price;
+        public readonly double remaining;
 
-        public Order(string id, string marketPair, string clientOrderId, ulong createdAt, OrderType orderType, Side side, OrderStatus status, double size, double price)
+        public Order(string id, string marketPair, string clientOrderId, ulong createdAt, OrderType orderType, Side side, OrderStatus status, double size, double price, double remaining)
         {
             this.id = id;
             this.marketPair = marketPair;
@@ -57,6 +60,7 @@ namespace OpenLimits
             this.status = status;
             this.size = size;
             this.price = price;
+            this.remaining = remaining;
         }
 
         public override bool Equals(object obj)
@@ -81,6 +85,7 @@ namespace OpenLimits
                 ", status='" + status + '\'' +
                 ", size='" + size + '\'' +
                 ", price='" + price + '\'' +
+                ", remaining='" + remaining + '\'' +
                 '}';
         }
     }

--- a/OpenLimitsTest/ExchangeClientTest.cs
+++ b/OpenLimitsTest/ExchangeClientTest.cs
@@ -58,7 +58,10 @@ namespace OpenLimitsTest
             TestContext.Progress.WriteLine("GetHistoricRates: " + client.GetHistoricTrades(new GetHistoricTradesRequest("btc_usdc")));
             TestContext.Progress.WriteLine("GetOrderHistory btc_usdc: " + client.GetOrderHistory(new GetOrderHistoryRequest("btc_usdc")));
             client.CancelAllOrders("btc_usdc");
-            TestContext.Progress.WriteLine("Limit sell: " + client.LimitSell(LimitOrderRequest.goodTillCancelled("6500.0", "0.01000", "btc_usdc")));
+            var order = client.LimitSell(LimitOrderRequest.goodTillCancelled("6500.0", "0.01000", "btc_usdc"));
+            
+            TestContext.Progress.WriteLine("Limit sell: " + order);
+            TestContext.Progress.WriteLine("Get order", client.GetOrder(order.id, order.marketPair));
             TestContext.Progress.WriteLine("Limit buy: " + client.LimitBuy(LimitOrderRequest.goodTillCancelled("6500.0", "0.01000", "btc_usdc")));
             TestContext.Progress.WriteLine("Limit buy fok: " + client.LimitSell(LimitOrderRequest.fillOrKill("6500.0", "0.01000", "btc_usdc")));
             TestContext.Progress.WriteLine("Limit buy ioc: " + client.LimitSell(LimitOrderRequest.immediateOrCancel("6500.0", "0.01000", "btc_usdc")));

--- a/OpenLimitsTestApp/Program.cs
+++ b/OpenLimitsTestApp/Program.cs
@@ -25,15 +25,15 @@ namespace OpenLimitsTestApp
             NashClientConfig config = NashClientConfig.Unauthenticated(0, NashEnvironment.Production, 1000);
             var client = new ExchangeClient(config);
 
-            Console.WriteLine("Available markets");
+            client.SubscribeToDisconnect(() => {
+                Console.WriteLine("Disconnected");
+            });
             foreach(var market in client.ReceivePairs()) {
-                Console.WriteLine("Market: " + market.symbol);
-                PrintBook(client.Orderbook(market.symbol));
+                client.SubscribeToOrderbook(market.symbol, PrintBook);
             }
-            
-            Console.WriteLine("Listening to the btc_usdc market");
-            PrintBook(client.Orderbook("btc_usdc"));
-            client.SubscribeToOrderbook("btc_usdc", PrintBook);
+
+            GC.Collect();  
+            GC.WaitForPendingFinalizers();
             
             // Noia markets only available in NashEnvironment.Production
             // Console.WriteLine("Listening to the noia markets");


### PR DESCRIPTION
Also made it possible to subscribe for Errors, Pings and Disconnects. This will be preferred over using the `.Listen()` method.